### PR TITLE
Fixes for python3, TLS

### DIFF
--- a/sleekxmpp/plugins/xep_0009/remote.py
+++ b/sleekxmpp/plugins/xep_0009/remote.py
@@ -412,7 +412,7 @@ class Proxy(Endpoint):
         self._callback = callback
 
     def __getattribute__(self, name, *args):
-        if name in ('__dict__', '_endpoint', 'async', '_callback'):
+        if name in ('__dict__', '_endpoint', 'asyncfn', '_callback'):
             return object.__getattribute__(self, name)
         else:
             attribute = self._endpoint.__getattribute__(name)
@@ -427,7 +427,7 @@ class Proxy(Endpoint):
                     pass   # If the attribute doesn't exist, don't care!
             return attribute
 
-    def async(self, callback):
+    def asyncfn(self, callback):
         return Proxy(self._endpoint, callback)
 
     def get_endpoint(self):

--- a/sleekxmpp/version.py
+++ b/sleekxmpp/version.py
@@ -9,5 +9,5 @@
 # We don't want to have to import the entire library
 # just to get the version info for setup.py
 
-__version__ = '1.4.0'
-__version_info__ = (1, 4, 0, '', 0)
+__version__ = '1.4.1'
+__version_info__ = (1, 4, 1, '', 0)

--- a/sleekxmpp/xmlstream/cert.py
+++ b/sleekxmpp/xmlstream/cert.py
@@ -61,22 +61,21 @@ def extract_names(raw_cert):
 
     cert = decoder.decode(raw_cert, asn1Spec=Certificate())[0]
     tbs = cert.getComponentByName('tbsCertificate')
-    subject = tbs.getComponentByName('subject')
+    subject = tbs.getComponentByName('subject')[0]
     extensions = tbs.getComponentByName('extensions') or []
 
     # Extract the CommonName(s) from the cert.
     for rdnss in subject:
         for rdns in rdnss:
-            for name in rdns:
-                oid = name.getComponentByName('type')
-                value = name.getComponentByName('value')
+            name = rdns.getComponentByName('type')
+            value = rdns.getComponentByName('value')
 
-                if oid != COMMON_NAME:
-                    continue
+            if name != COMMON_NAME:
+                continue
 
-                value = decoder.decode(value, asn1Spec=DirectoryString())[0]
-                value = decode_str(value.getComponent())
-                results['CN'].add(value)
+            value = decoder.decode(value, asn1Spec=DirectoryString())[0]
+            value = decode_str(value.getComponent())
+            results['CN'].add(value)
 
     # Extract the Subject Alternate Names (DNS, SRV, URI, XMPPAddr)
     for extension in extensions:

--- a/sleekxmpp/xmlstream/xmlstream.py
+++ b/sleekxmpp/xmlstream/xmlstream.py
@@ -459,10 +459,6 @@ class XMLStream(object):
                 # Good, create_default_context() is supported, which consists
                 # recommended security settings by default.
                 ctx = ssl.create_default_context()
-                if self.ssl_version == ssl.PROTOCOL_SSLv3:
-                    # But if the user specifies insecure SSLv3, do a favor.
-                    ctx.options &= ~ssl.OP_NO_SSLv3  # UNSET NO_SSLv3, or set SSLv3
-                    ctx.set_ciphers(_CIPHERS_SSL)  # _CIPHERS_SSL is weaker
 
                 # XXX: certificate is not verified in most circumstances.
                 # FIXME: need to provide a new option that verifies against system CAs.
@@ -473,15 +469,8 @@ class XMLStream(object):
                     ctx.load_verify_locations(cafile=self.ca_certs)
             else:
                 # Oops, create_default_context() is not supported.
-                if self.ssl_version == ssl.PROTOCOL_SSLv3:
-                    # First, if the user specifies insecure SSLv3, do a favor.
-                    ctx = ssl.SSLContext(ssl.PROTOCOL_SSLv3)
-                    ctx.set_ciphers(_CIPHERS_SSL)
-                else:
-                    # Or, set the version to TLSv1 (later is not supported),
-                    # and set a list of good ciphers.
-                    ctx = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
-                    ctx.set_ciphers(_CIPHERS_TLS)
+                ctx = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+                ctx.set_ciphers(_CIPHERS_TLS)
                 # And in both case, CRIME attack needs to be prevented.
                 if sys.version_info >= (3, 3):
                     ctx.options &= ssl.OP_NO_COMPRESSION
@@ -497,10 +486,6 @@ class XMLStream(object):
         elif sys.version_info >= (2, 7, 9):
             # Good, create_default_context() is supported, do the same as Python 3.4.
             ctx = ssl.create_default_context()
-            if self.ssl_version == ssl.PROTOCOL_SSLv3:
-                # If the user specifies insecure SSLv3, do a favor.
-                ctx.options &= ~ssl.OP_NO_SSLv3
-                ctx.set_ciphers(_CIPHERS_SSL)
             if cert_policy == ssl.CERT_NONE:
                 # XXX: certificate is not verified!
                 ctx.check_hostname = False
@@ -508,10 +493,7 @@ class XMLStream(object):
             elif cert_policy == ssl.CERT_REQUIRED:
                 ctx.load_verify_locations(cafile=self.ca_certs)
         else:
-            if self.ssl_version == ssl.PROTOCOL_SSLv3:
-                ssl_args['ssl_version'] = ssl.PROTOCOL_SSLv3
-            else:
-                ssl_args['ssl_version'] = ssl.PROTOCOL_TLSv1
+            ssl_args['ssl_version'] = ssl.PROTOCOL_TLSv1
             ctx = None
 
         if ctx:


### PR DESCRIPTION
1) Rename 'async' function (not allowed in python3 due to conflict with 'async' keyword)
2) Remove references to PROTOCOL_SSLv3 (removed from Ubuntu for security purposes)
3) Fix TLS certificate decoding